### PR TITLE
Fix crash in visual crop tool by removing Tkinter messagebox

### DIFF
--- a/src/peg_this/features/crop.py
+++ b/src/peg_this/features/crop.py
@@ -47,7 +47,7 @@ def crop_video(file_path):
         root.attributes("-topmost", True)
 
         img = Image.open(preview_frame)
-        img_tk = ImageTk.PhotoImage(img)
+        img_tk = ImageTk.PhotoImage(img, master=root)
 
         canvas = tk.Canvas(root, width=img.width, height=img.height, cursor="cross")
         canvas.pack()
@@ -108,6 +108,13 @@ def crop_video(file_path):
         console.print(f"[bold green]Successfully cropped video and saved to {output_file}[/bold green]")
 
     finally:
+        # Ensure Tkinter window is destroyed
+        if 'root' in locals() and root:
+            try:
+                root.destroy()
+            except Exception:
+                pass
+                
         if os.path.exists(preview_frame):
             os.remove(preview_frame)
         questionary.press_any_key_to_continue().ask()
@@ -133,7 +140,7 @@ def crop_image(file_path):
         max_height = root.winfo_screenheight() - 100
         img.thumbnail((max_width, max_height), Image.Resampling.LANCZOS)
         
-        img_tk = ImageTk.PhotoImage(img)
+        img_tk = ImageTk.PhotoImage(img, master=root)
 
         canvas = tk.Canvas(root, width=img.width, height=img.height, cursor="cross")
         canvas.pack()
@@ -189,4 +196,10 @@ def crop_image(file_path):
     except Exception as e:
         console.print(f"[bold red]An error occurred during cropping: {e}[/bold red]")
     finally:
+        # Ensure Tkinter window is destroyed
+        if 'root' in locals() and root:
+            try:
+                root.destroy()
+            except Exception:
+                pass
         questionary.press_any_key_to_continue().ask()

--- a/src/peg_this/features/crop.py
+++ b/src/peg_this/features/crop.py
@@ -10,7 +10,7 @@ from peg_this.utils.ffmpeg_utils import run_command, has_audio_stream
 
 try:
     import tkinter as tk
-    from tkinter import messagebox
+    # messagebox removed as it causes issues on some systems
     from PIL import Image, ImageTk
 except ImportError:
     tk = None
@@ -68,7 +68,14 @@ def crop_video(file_path):
         canvas.bind("<ButtonPress-1>", on_press)
         canvas.bind("<B1-Motion>", on_drag)
         
-        messagebox.showinfo("Instructions", "Click and drag to draw a cropping rectangle.\nClose this window when you are done.", parent=root)
+        # Avoid messagebox to prevent "application has been destroyed" errors
+        console.print("[bold cyan]Instructions: Click and drag to draw a cropping rectangle. Close the window when you are done.[/bold cyan]")
+        
+        # Ensure window comes to front
+        root.lift()
+        root.attributes('-topmost',True)
+        root.after_idle(root.attributes,'-topmost',False)
+        
         root.mainloop()
 
         # --- Cropping Logic ---
@@ -147,7 +154,14 @@ def crop_image(file_path):
         canvas.bind("<ButtonPress-1>", on_press)
         canvas.bind("<B1-Motion>", on_drag)
         
-        messagebox.showinfo("Instructions", "Click and drag to draw a cropping rectangle.\nClose this window when you are done.", parent=root)
+        # Avoid messagebox to prevent "application has been destroyed" errors
+        console.print("[bold cyan]Instructions: Click and drag to draw a cropping rectangle. Close the window when you are done.[/bold cyan]")
+        
+        # Ensure window comes to front
+        root.lift()
+        root.attributes('-topmost',True)
+        root.after_idle(root.attributes,'-topmost',False)
+        
         root.mainloop()
 
         # --- Cropping Logic ---


### PR DESCRIPTION
**Description**:
This PR fixes a runtime error in the visual crop feature (both for video and images) where the application would crash with can't invoke "grab" command: application has been destroyed.

**The Issue**:
Using messagebox.showinfo immediately after initializing the Tkinter root window was causing lifecycle management issues on some Linux environments/window managers. The modal dialog was conflicting with the main window's event loop initialization. As a result, the visual crop operation leads to crash and logs are shown in the end.

**The Fix**:
Removed the blocking messagebox.showinfo call.
Replaced instructions with a clear console.print message in the terminal.
Added root.lift() and temporary topmost attributes to ensure the cropping window appears above other windows when launched.
Cleaned up unused imports (messagebox).

**Verification**:
Visual cropping now launches the window reliably without crashing, and instructions are displayed in the console instead of a popup.

Visual crop crash log:
`GNU nano 6.2            
/home/phi/miniforge3/lib/python3.12/site-packages/peg_this/ffmpeg_log.txt                     
2025-12-11 15:22:03,974 - INFO - Executing command: ffmpeg -ss 94.6648955 -i /home/phi/Downloads/Screencast from 12-11->
2025-12-11 15:22:05,445 - INFO - Command successful (no progress bar).
2025-12-11 15:22:35,927 - ERROR - An unexpected error occurred.
Traceback (most recent call last):
  File "/home/phi/miniforge3/lib/python3.12/site-packages/peg_this/peg_this.py", line 142, in main
    main_menu()
  File "/home/phi/miniforge3/lib/python3.12/site-packages/peg_this/peg_this.py", line 132, in main_menu
    action_menu(selected_file)
  File "/home/phi/miniforge3/lib/python3.12/site-packages/peg_this/peg_this.py", line 103, in action_menu
    actions[action](file_path)
  File "/home/phi/miniforge3/lib/python3.12/site-packages/peg_this/features/crop.py", line 71, in crop_video
    messagebox.showinfo("Instructions", "Click and drag to draw a cropping rectangle.\nClose this window when you are d>
  File "/home/phi/miniforge3/lib/python3.12/tkinter/messagebox.py", line 88, in showinfo
    return _show(title, message, INFO, OK, **options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/phi/miniforge3/lib/python3.12/tkinter/messagebox.py", line 76, in _show
    res = Message(**options).show()
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/phi/miniforge3/lib/python3.12/tkinter/commondialog.py", line 45, in show
    s = master.tk.call(self.command, *master._options(self.options))
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_tkinter.TclError: can't invoke "grab" command: application has been destroyed`