### PR TITLE
Fix inaccurate start times in video trimming.

### DIFF
--- a/src/peg_this/features/trim.py
+++ b/src/peg_this/features/trim.py
@@ -5,7 +5,7 @@ import ffmpeg
 import questionary
 from rich.console import Console
 
-from peg_this.utils.ffmpeg_utils import run_command
+from peg_this.utils.ffmpeg_utils import run_command, has_audio_stream
 
 console = Console()
 
@@ -19,7 +19,21 @@ def trim_video(file_path):
 
     output_file = f"{Path(file_path).stem}_trimmed{Path(file_path).suffix}"
     
-    stream = ffmpeg.input(file_path, ss=start_time, to=end_time).output(output_file, c='copy', y=None)
+    input_stream = ffmpeg.input(file_path)
+    
+    # Build output with accurate seeking
+    output_kwargs = {
+        'ss': start_time,
+        'to': end_time,
+        'y': None
+    }
+    
+    # Handle audio stream if present
+    if has_audio_stream(file_path):
+        output_kwargs['c:a'] = 'copy'  # Audio can still be copied
+        stream = ffmpeg.output(input_stream.video, input_stream.audio, output_file, **output_kwargs)
+    else:
+        stream = ffmpeg.output(input_stream, output_file, **output_kwargs)
     
     run_command(stream, "Trimming video...", show_progress=True)
     console.print(f"[bold green]Successfully trimmed to {output_file}[/bold green]")


### PR DESCRIPTION
**Description**:
This PR fixes a bug in the trim feature where specifying a start time (e.g., "7s") would often result in the video starting from 0s.

**Issue**:
The previous implementation generated a command like ffmpeg -ss ... -i ... -c copy. When using input seeking (-ss before -i) combined with stream copy, FFmpeg snaps the start point to the nearest keyframe. If the specified start time wasn't a keyframe, it would often revert to the beginning of the file.

**Fix**:
Switched from stream copy (-c copy) to re-encoding for the video stream.
Moved the -ss and -to arguments to the output side (after -i).
Preserved -c:a copy for audio streams to minimize performance impact.

**Trade-off**:
Trimming is now frame-accurate but slower, as it requires re-encoding the video stream rather than just copying bits.